### PR TITLE
Update auth plugin for marathon 1.1.1

### DIFF
--- a/auth/build.sbt
+++ b/auth/build.sbt
@@ -5,7 +5,7 @@ version := "1.0"
 resolvers += "Mesosphere Public Repo" at "http://downloads.mesosphere.io/maven"
 
 libraryDependencies ++= Seq(
-  "mesosphere.marathon" %% "plugin-interface" % "0.13.0" % "provided",
+  "mesosphere.marathon" %% "plugin-interface" % "1.1.1" % "provided",
   "log4j" % "log4j" % "1.2.17" % "provided"
 )
 

--- a/auth/src/main/resources/mesosphere/marathon/example/plugin/auth/plugin-conf.json
+++ b/auth/src/main/resources/mesosphere/marathon/example/plugin/auth/plugin-conf.json
@@ -17,7 +17,6 @@
               { "allowed": "update", "on": "/dev/" },
               { "allowed": "delete", "on": "/dev/" },
               { "allowed": "view", "on": "/dev/" },
-              { "allowed": "killTask", "on": "/dev/" }
             ]
           },
           {
@@ -28,7 +27,6 @@
               { "allowed": "update", "on": "/prod/" },
               { "allowed": "delete", "on": "/prod/" },
               { "allowed": "view", "on": "/prod/" },
-              { "allowed": "killTask", "on": "/prod/" }
             ]
           },
           {
@@ -39,7 +37,6 @@
               { "allowed": "update", "on": "/" },
               { "allowed": "delete", "on": "/" },
               { "allowed": "view", "on": "/" },
-              { "allowed": "killTask", "on": "/" }
             ]
           }
         ]

--- a/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleAuthenticator.scala
+++ b/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleAuthenticator.scala
@@ -43,7 +43,7 @@ class ExampleAuthenticator extends Authenticator with PluginConfiguration {
 
   private var identities = Map.empty[String, ExampleIdentity]
 
-  override def initialize(configuration: JsObject): Unit = {
+  override def initialize(marathonInfo: Map[String, Any], configuration: JsObject): Unit = {
     //read all identities from the configuration
     identities = (configuration \ "users").as[Seq[ExampleIdentity]].map(id => id.username -> id).toMap
   }

--- a/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleAuthorizer.scala
+++ b/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleAuthorizer.scala
@@ -5,14 +5,14 @@ import mesosphere.marathon.plugin.http._
 
 class ExampleAuthorizer extends Authorizer {
 
-  override def handleNotAuthorized(principal: Identity, request: HttpRequest, response: HttpResponse): Unit = {
+  override def handleNotAuthorized(principal: Identity, response: HttpResponse): Unit = {
     response.status(403)
     response.body("application/json", s"""{"message": "Not Authorized to perform this action!"}""".getBytes("UTF-8"))
   }
 
-  override def isAuthorized[Resource](principal: Identity,
-                                      action: AuthorizedAction[Resource],
-                                      resource: Resource): Boolean = {
+  override def isAuthorized[R](principal: Identity,
+                                      action: AuthorizedAction[R],
+                                      resource: R): Boolean = {
     principal match {
       case identity: ExampleIdentity => identity.isAllowed(action, resource)
       case _                      => false

--- a/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleIdentity.scala
+++ b/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/ExampleIdentity.scala
@@ -6,12 +6,12 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
 
-case class ExampleIdentity(username: String, password: String, permissions: Set[Permission[_]]) extends Identity {
+case class ExampleIdentity(username: String, password: String, permissions: Seq[Permission]) extends Identity {
   val log = Logger.getLogger(classOf[ExampleIdentity])
 
-  def isAllowed[Resource](action: AuthorizedAction[Resource], resource: Resource): Boolean = {
+  def isAllowed[R](action: AuthorizedAction[R], resource: R): Boolean = {
     val permit = permissions.find { permission =>
-      permission.eligible(action) && permission.asInstanceOf[Permission[Resource]].isAllowed(resource)
+      permission.eligible(action) && permission.isAllowed(resource)
     }
     permit match {
       case Some(p) => log.info(s"Found permit: $p")
@@ -25,7 +25,7 @@ object ExampleIdentity {
   implicit val identityRead: Reads[ExampleIdentity] = (
     (__ \ "user").read[String] ~
     (__ \ "password").read[String] ~
-    (__ \ "permissions").read[Set[PathPermission]]
-  ) ((name, pass, permission) => ExampleIdentity(name, pass, permission.asInstanceOf[Set[Permission[_]]]))
+    (__ \ "permissions").read[Seq[PathPermission]]
+  ) ((name, pass, permissions) => ExampleIdentity(name, pass, permissions))
 }
 

--- a/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/Permission.scala
+++ b/auth/src/main/scala/mesosphere/marathon/example/plugin/auth/Permission.scala
@@ -1,23 +1,23 @@
 package mesosphere.marathon.example.plugin.auth
 
-import mesosphere.marathon.plugin
+import mesosphere.marathon.plugin.AppDefinition
+import mesosphere.marathon.plugin.Group
 import mesosphere.marathon.plugin.auth._
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 
-trait Permission[A] {
-  def eligible[T](action: AuthorizedAction[T]): Boolean
-  def isAllowed(resource: A): Boolean
+trait Permission {
+  def eligible[R](action: AuthorizedAction[R]): Boolean
+  def isAllowed[R](resource: R): Boolean
 }
 
 object Permission {
 
-  private def actionByName(name: String): AuthorizedAction[plugin.PathId] = name match {
-    case "create" => CreateAppOrGroup
-    case "update" => UpdateAppOrGroup
-    case "delete" => DeleteAppOrGroup
-    case "view" => ViewAppOrGroup
-    case "killTask" => KillTask
+  private def actionByName(name: String): Seq[AuthorizedAction[_]] = name match {
+    case "create" => Seq(CreateApp, CreateGroup)
+    case "update" => Seq(UpdateApp, UpdateGroup)
+    case "delete" => Seq(DeleteApp, DeleteGroup)
+    case "view" => Seq(ViewApp, ViewGroup)
   }
 
   implicit lazy val permissionReads: Reads[PathPermission] = (
@@ -27,9 +27,14 @@ object Permission {
 
 }
 
-case class PathPermission(allowed: AuthorizedAction[plugin.PathId], on: String) extends Permission[plugin.PathId] {
-  override def eligible[T](requested: AuthorizedAction[T]): Boolean = requested == allowed
-  override def isAllowed(resource: plugin.PathId): Boolean = resource.toString().startsWith(on)
+case class PathPermission(allowed: Seq[AuthorizedAction[_]], on: String) extends Permission {
+
+  override def eligible[R](requested: AuthorizedAction[R]): Boolean = allowed.contains(requested)
+  override def isAllowed[R](resource: R): Boolean = resource match {
+    case app: AppDefinition => app.id.toString.startsWith(on)
+    case group: Group => group.id.toString.startsWith(on)
+    case _ => false
+  }
   override def toString: String = s"Permission(allow: $allowed, on: $on)"
 }
 


### PR DESCRIPTION
* Removed `plugin.PathId` and instead pattern match on the `Resource` type of `AuthorizedAction[Resource]` (either `AppDefinition` or `Group`)
* Marathon 1.1.1 has separate permissions for Apps and Groups now, but I've kept the structure of the permissions json file the same, so
```json
"permissions": [
    { "allowed": "create", "on": "/dev/" }
]
```
will allow create on /dev apps AND groups
* removes `killTask` permissions appear to be removed in marathon 1.1.1 (I assume they were just rolled into the delete app/group permissions